### PR TITLE
fix(emqx): pin operator to 2.2.29 (2.3.0 requires EMQX 5.9+ Enterprise)

### DIFF
--- a/kubernetes/apps/iot/emqx/app/helmrelease.yaml
+++ b/kubernetes/apps/iot/emqx/app/helmrelease.yaml
@@ -18,7 +18,9 @@ spec:
   chart:
     spec:
       chart: emqx-operator
-      version: 2.3.0
+      # 2.3.0 requires EMQX 5.9+ (calls /api/v5/load_rebalance/global_status).
+      # Stay on 2.2.x until we bump EMQX core.
+      version: 2.2.29
       sourceRef:
         kind: HelmRepository
         name: emqx-operator


### PR DESCRIPTION
## Summary
- Revert the renovate-driven bump of \`emqx-operator\` from 2.2.29 → 2.3.0 (#747).
- The 2.3.0 reconciler calls \`/api/v5/load_rebalance/global_status\`, an endpoint that exists only in EMQX 5.9+ (Enterprise). Open-source EMQX is still on 5.8.x — there is no v5.9 OSS release.
- On our 5.8.9 OSS image the operator gets a 404, fails reconcile at \`updateStatus\`, and never marks the \`apps.emqx.io/on-serving\` readiness gate True.
- Result: EndpointSlice keeps the cores unready, so any new MQTT client (e.g. Home Assistant after a pod restart) gets connection refused. Existing TCP sessions (z2m-a, z2m-b) stayed up because cilium doesn't tear down established flows.

## Symptoms observed
- All z2m-a / z2m-b devices showed unavailable in Home Assistant.
- \`emqx_ctl clients list\` showed only the two pre-existing z2m connections — no HA client.
- HA logs: a single \`Failed to connect to MQTT server: [Errno 111] Connection refused\` at startup, never retried successfully.
- Operator logs: tight loop of \`reconcile failed at step updateStatus … HTTP 404 … load_rebalance/global_status\`.

## Forward path
EMQX 5.9 / 5.10 / 6.x are Enterprise-only releases (\`e5.x.x\` tags). Moving forward on this operator track means switching the image to \`emqx-enterprise\`, which has license implications. Pinning the operator is the right call until/unless we make that switch.

## Follow-up (separate)
- Add \`emqx-operator\` to a renovate ignore (or pin to \`~2.2\`) so PR #747 doesn't reopen.

## Test plan
- [ ] Flux reconciles, operator pod rolls back to 2.2.29.
- [ ] \`kubectl -n iot get pod emqx-core-... -o jsonpath='{.status.conditions[?(@.type==\"apps.emqx.io/on-serving\")].status}'\` returns True on both cores.
- [ ] \`kubectl -n iot get endpointslices -l kubernetes.io/service-name=emqx-listeners\` shows ready endpoints.
- [ ] HA reconnects to MQTT (visible in \`emqx_ctl clients list\` as username \`homeassistant\`).
- [ ] z2m-a entities in HA come back online.